### PR TITLE
avoid using the system python binary

### DIFF
--- a/scripts/leaderboard.py
+++ b/scripts/leaderboard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 This script will grab the leaderboard from Advent of Code and post it to Slack


### PR DESCRIPTION
Because the `requests` module won't always be installed in the system python path, it would be better to check the local environment for a python instance with higher precedence. What do you think?

By the way, this will be my first Slack Bot; thanks for the template. Very useful.